### PR TITLE
Update RFC0005-ETags.md - Chris Lewis comments

### DIFF
--- a/documentation/RFC/RFC0005-ETags.md
+++ b/documentation/RFC/RFC0005-ETags.md
@@ -41,6 +41,9 @@ Update-AzVM <parameters> -ETag <etag-value>
 Get-AzVM <parameters> | Update-AzVM <changed parameters>
 ```
 
+- I would say this pipeline example is a little vague - is this using etag or not.  Or would input from pipeline use a different default behavior.
+
+
 
 ### Forcing Updates
 
@@ -50,8 +53,29 @@ Update a resource regardless of ETag settings
 Update-AzVM <parameters> -Overwrite
 ```
 
+- Overwrite is pretty non-standard powershell.  -Force or -Confirm would be better (See https://stackoverflow.com/questions/34749333/powershell-guidelines-for-confirm-force-and-whatif and https://github.com/Azure/azure-powershell/issues/475)
+
 ## Comments and Questions
 
 - Should Updates be conditional on ETag value match by default, or shoudl this be opt-in
-
+ 
 - Should overwrite without regard to ETag values be an opt-in or default behavior
+
+
+I believe this should be rolled  in gradually, so initial release should have etags usage as optional.  Let it bake for 6 months and then switch the default behavior. 
+
+I could see:
+Get-AzVM <parameters> | Update-AzVM <changed parameters> -UseEtag $true
+ 
+Where UseEtag's default value changes from $false to $true after a while.  This would initally not break scripts, but after the roll-out date all new `Update-AzVM` commands would use the ETAG checking.
+ 
+### Question 
+How do etags work with sub-items i.e. network config.  Do those sub items have a separate etag and updates to them cause the parent object etag to update also?  
+
+This is going to have to be *clearly* documented - I could see some real confusion in this path:
+
+Get-AzVM ->  (Change Disk Size via $vm.StorageProfile.DataDisks[0].DiskSizeGB = 123 ) -> Update-AzVM 
+
+vs
+
+Get-AzVM ->  get-AzDataDisk -> (Change Disk Size via Set-AzDataDisk) -> Update-AzVM 


### PR DESCRIPTION
Comments from Chris Lewis regarding new Etag usage in Powershell Update-AzXXX commands

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!-- Please add a brief description of the changes made in this PR -->
Comments from Chris Lewis regarding new Etag usage in Powershell Update-AzXXX commands


## Checklist

- [ X ] I have read the [_Submitting Changes_](../CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../CONTRIBUTING.md)
- [ X  ] The title of the PR is clear and informative
- [ N/A ] The appropriate `ChangeLog.md` file(s) has been updated:
    - For any service, the `ChangeLog.md` file can be found at `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`
    - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header -- no new version header should be added
- [ N/A ] The PR does not introduce [breaking changes](../documentation/breaking-changes/breaking-changes-definition.md)
- [ N/A ] If applicable, the changes made in the PR have proper test coverage
- [ N/A ] For public API changes to cmdlets:
    - [ N/A ] a cmdlet design review was approved for the changes in [this repository](https://github.com/Azure/azure-powershell-cmdlet-review-pr) (_Microsoft internal only_)
    - [ N/A ] the markdown help files have been regenerated using the commands listed [here](../documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
